### PR TITLE
django 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ env:
   - DJANGO=1.8 DRF=3.2
   - DJANGO=1.9 DRF=3.1
   - DJANGO=1.9 DRF=3.2
-  - DJANGO=1.9 DRF=3.3
 matrix:
   exclude:
    - python: "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ env:
   - DJANGO=1.7 DRF=3.2
   - DJANGO=1.8 DRF=3.1
   - DJANGO=1.8 DRF=3.2
+  - DJANGO=1.9 DRF=3.1
+  - DJANGO=1.9 DRF=3.2
+  - DJANGO=1.9 DRF=3.3
 matrix:
   exclude:
    - python: "3.5"

--- a/drf_generators/management/commands/generate.py
+++ b/drf_generators/management/commands/generate.py
@@ -47,7 +47,7 @@ class Command(AppCommand):
             views = options['views'] if 'views' in options else False
             urls = options['urls'] if 'urls' in options else False
 
-        elif django.VERSION[1] == 8:
+        elif django.VERSION[1] >= 8:
             force = options['force']
             format = options['format']
             depth = options['depth']
@@ -55,7 +55,7 @@ class Command(AppCommand):
             views = options['views']
             urls = options['urls']
         else:
-            raise CommandError('You must be using Django 1.7 or 1.8')
+            raise CommandError('You must be using Django 1.7, 1.8 or 1.9')
 
         if format == 'viewset':
             generator = ViewSetGenerator(app_config, force)


### PR DESCRIPTION
Quick fix for django.VERSION's check. Allow to use not only 1.8 version but higher.
