### PR TITLE
add fields = '__all__' to serializer template

### DIFF
--- a/drf_generators/templates/serializer.py
+++ b/drf_generators/templates/serializer.py
@@ -11,4 +11,5 @@ class {{ model }}Serializer(ModelSerializer):
     class Meta:
         model = {{ model }}{% if depth != 0 %}
         depth = {{ depth }}{% endif %}
+        fields = '__all__'
 {% endfor %}"""


### PR DESCRIPTION
ModelSerializer and HyperlinkedModelSerializer must include either a fields option, or an exclude option. The fields = '__all__' shortcut may be used to explicitly include all fields.

*Failing to set either fields or exclude raised a pending deprecation warning in version 3.3 and raised a deprecation warning in 3.4. Its usage is now mandatory.*

http://www.django-rest-framework.org/topics/3.5-announcement/#modelserializer-fields-and-exclude