### PR TITLE
add exclude = () for DRF 3.3 compatability

### DIFF
--- a/drf_generators/templates/serializer.py
+++ b/drf_generators/templates/serializer.py
@@ -11,4 +11,5 @@ class {{ model }}Serializer(ModelSerializer):
     class Meta:
         model = {{ model }}{% if depth != 0 %}
         depth = {{ depth }}{% endif %}
+        exclude = ()
 {% endfor %}"""


### PR DESCRIPTION
"Serializers must include either a fields option, or an exclude option."
source: http://www.django-rest-framework.org/topics/3.5-announcement/#modelserializer-fields-and-exclude

alternate solutions proposed here: https://github.com/Brobin/drf-generators/pull/26