### PR TITLE
Update to support django version 1.10 and rest framework version 3.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ pip-delete-this-directory.txt
 # Virtualenv
 py2venv
 py3venv
+venv/
+
+# Pycharm
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ env:
   - DJANGO=1.8 DRF=3.2
   - DJANGO=1.9 DRF=3.2
   - DJANGO=1.9 DRF=3.3
+  - DJANGO=1.9 DRF=3.4
+  - DJANGO=1.10 DRF=3.4
+  - DJANGO=1.10 DRF=3.5
 matrix:
   exclude:
    - python: "3.5"

--- a/drf_generators/management/commands/generate.py
+++ b/drf_generators/management/commands/generate.py
@@ -1,7 +1,5 @@
-
 from django.core.management.base import AppCommand, CommandError
 from drf_generators.generators import *
-from optparse import make_option
 import django
 
 
@@ -10,27 +8,27 @@ class Command(AppCommand):
 
     args = "[appname ...]"
 
-    base_options = (
-        make_option('-f', '--format', dest='format', default='viewset',
-                    help='view format (default: viewset)'),
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument('-f', '--format', dest='format',
+                            default='viewset',
+                            help='view format (default: viewset)'),
 
-        make_option('-d', '--depth', dest='depth', default=0,
-                    help='serialization depth'),
+        parser.add_argument('-d', '--depth', dest='depth', default=0,
+                            help='serialization depth'),
 
-        make_option('--force', dest='force', action='store_true',
-                    help='force overwrite files'),
+        parser.add_argument('--force', dest='force', action='store_true',
+                            help='force overwrite files'),
 
-        make_option('--serializers', dest='serializers', action='store_true',
-                    help='generate serializers only'),
+        parser.add_argument('--serializers', dest='serializers',
+                            action='store_true',
+                            help='generate serializers only'),
 
-        make_option('--views', dest='views', action='store_true',
-                    help='generate views only'),
+        parser.add_argument('--views', dest='views', action='store_true',
+                            help='generate views only'),
 
-        make_option('--urls', dest='urls', action='store_true',
-                    help='generate urls only'),
-    )
-
-    option_list = AppCommand.option_list + base_options
+        parser.add_argument('--urls', dest='urls', action='store_true',
+                            help='generate urls only'),
 
     def handle_app_config(self, app_config, **options):
         if app_config.models_module is None:

--- a/drf_generators/templates/apiview.py
+++ b/drf_generators/templates/apiview.py
@@ -2,17 +2,29 @@
 __all__ = ['API_VIEW', 'API_URL']
 
 
-API_URL = """from django.conf.urls import patterns, include, url
+API_URL = """from django.conf.urls import include, url
+try:
+  from django.conf.urls import patterns
+except ImportError:
+  pass
+import django
 from django.contrib import admin
 from {{ app }} import views
 
-
-urlpatterns = patterns('',
-{% for model in models %}
+if django.VERSION[1] < 10:
+  urlpatterns = patterns('',
+  {% for model in models %}
     url(r'^{{ model|lower }}/(?P<id>[0-9]+)$', views.{{ model }}APIView.as_view()),
     url(r'^{{ model|lower }}/$', views.{{ model }}APIListView.as_view()),
-{% endfor %}
-)
+  {% endfor %}
+  )
+else:
+  urlpatterns = [
+  {% for model in models %}
+    url(r'^{{ model|lower }}/(?P<id>[0-9]+)$', views.{{ model }}APIView.as_view()),
+    url(r'^{{ model|lower }}/$', views.{{ model }}APIListView.as_view()),
+  {% endfor %}
+  ]
 """
 
 

--- a/drf_generators/templates/serializer.py
+++ b/drf_generators/templates/serializer.py
@@ -1,4 +1,4 @@
-
+import rest_framework
 __all__ = ['SERIALIZER']
 
 
@@ -10,5 +10,12 @@ class {{ model }}Serializer(ModelSerializer):
 
     class Meta:
         model = {{ model }}{% if depth != 0 %}
-        depth = {{ depth }}{% endif %}
+        depth = {{ depth }}{% endif %}"""
+
+if int(rest_framework.__version__.split('.')[1]) > 4:
+    SERIALIZER += """
+        fields = '__all__'
+"""
+
+SERIALIZER += """
 {% endfor %}"""


### PR DESCRIPTION
Updated to support django version 1.10

Fix removal AppCommand.option_list in Django v1.10+
This is using the add_arguments method instead which is back compatible.

Fix requiring Meta.field in serializers for rest framework 3.5